### PR TITLE
fix: constrain Node.js version to avoid v23 compatibility issues

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=20 <23"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Constrain Node.js version to exclude v23.x which is incompatible with dependencies
- Fixes build failure on DigitalOcean App Platform

## Problem
The build was failing with the following error:
```
npm error engine Not compatible with your version of node/npm: @jest/diff-sequences@30.0.1
npm error notsup Required: {"node":"^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"}
npm error notsup Actual:   {"npm":"10.9.2","node":"v23.10.0"}
```

The dependency `@jest/diff-sequences@30.0.1` doesn't support Node.js v23.x - it jumps from v22 to v24+.

## Solution
Updated the Node.js engine constraint in `client/package.json` from `>=20` to `>=20 <23` to exclude the unsupported v23.x versions.

## Test plan
- [ ] Build succeeds on DigitalOcean App Platform
- [ ] Local development still works with Node.js v20.x or v22.x

🤖 Generated with [Claude Code](https://claude.ai/code)